### PR TITLE
Add failing test for async end

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "url": "git://github.com/dominictarr/pull-stream-to-stream.git"
   },
   "dependencies": {
-    "pull-core": "1"
   },
   "devDependencies": {
     "pull-stream": ">=2.10 <3",

--- a/test/close.js
+++ b/test/close.js
@@ -20,6 +20,7 @@ require('tape')('test close', function (t) {
 
 })
 
+
 require('tape')('test end', function (t) {
 
   t.plan(10)
@@ -34,4 +35,26 @@ require('tape')('test end', function (t) {
     if(!--i) cs.end()
   })
 
+})
+
+require('tape')('test end async', function (t) {
+
+  t.plan(10)
+
+  var source = pull(pull.infinite(), pull.take(10))
+  var cs = CS(pull.asyncMap(function (val, cb) {
+    setTimeout(function () {
+      cb(null, val)
+    }, 10)
+  }), source)
+
+  cs.on('data', function (data) {
+    t.ok(data)
+  })
+
+  cs.on('end', function () {
+    t.end()
+  })
+
+  cs.end()
 })

--- a/test/close.js
+++ b/test/close.js
@@ -41,12 +41,15 @@ require('tape')('test end async', function (t) {
 
   t.plan(10)
 
-  var source = pull(pull.infinite(), pull.take(10))
-  var cs = CS(pull.asyncMap(function (val, cb) {
-    setTimeout(function () {
-      cb(null, val)
-    }, 10)
-  }), source)
+  var cs = CS(pull(
+    pull.infinite(),
+    pull.take(10),
+    pull.asyncMap(function (val, cb) {
+      setTimeout(function () {
+        cb(null, val)
+      }, 10)
+    })
+  ))
 
   cs.on('data', function (data) {
     t.ok(data)

--- a/test/close.js
+++ b/test/close.js
@@ -41,15 +41,11 @@ require('tape')('test end async', function (t) {
 
   t.plan(10)
 
-  var cs = CS(pull(
-    pull.infinite(),
-    pull.take(10),
-    pull.asyncMap(function (val, cb) {
-      setTimeout(function () {
-        cb(null, val)
-      }, 10)
-    })
-  ))
+  var cs = CS(pull.asyncMap(function (val, cb) {
+    setTimeout(function () {
+      cb(null, val)
+    }, 10)
+  }))
 
   cs.on('data', function (data) {
     t.ok(data)
@@ -58,6 +54,10 @@ require('tape')('test end async', function (t) {
   cs.on('end', function () {
     t.end()
   })
+
+  for (var i=0;i<10;i++) {
+    cs.write(Buffer('world'))
+  }
 
   cs.end()
 })

--- a/test/test2.js
+++ b/test/test2.js
@@ -20,18 +20,21 @@ test('header', function (t) {
     defer.pipe(d.sink) //pass output to source
 
     //pull one item "HEADER" from source.
-    d.source.pipe(function (read) {
-      read(null, function (err, len) {
-        defer.resolve(
-          pull.infinite()
-          .pipe(pull.take(Number(len)))
-          .pipe(pull.map(function (n) {
-            a.push(n)
-            return n + '\n'
-          }))
-        )
-      })
-    })
+    pull(
+      d.source,
+      function (read) {
+        read(null, function (err, len) {
+          defer.resolve(
+            pull.infinite()
+              .pipe(pull.take(Number(len)))
+              .pipe(pull.map(function (n) {
+                a.push(n)
+                return n + '\n'
+              }))
+          )
+        })
+      }
+    )
 
   }).listen(0, function () {
     var stream = net.connect(server.address().port)
@@ -53,4 +56,3 @@ test('header', function (t) {
     })
   })
 })
-


### PR DESCRIPTION
So I'm trying to adhere to an interface based on node.js streams by doing the work in a pull-stream and then calling`pullStreamToStream` on it. The interface test writes to the stream and then ends it, but because the internal processing is asynchronous the stream is ended before all the results are emitted. 

I've a failing test case here and would love some feedback if this is actually a bug to be fixed here or if this should be solved in a different way. 
