### PR TITLE
fix: readable streams are resumed when piped

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,18 @@ function duplex (reader, read) {
     next(drain)
   }
 
-  if(read) s.sink(read)
+  if(read) {
+    s.sink(read)
+
+    var pipe = s.pipe.bind(s)
+    s.pipe = function (dest, opts) {
+      var res = pipe(dest, opts)
+
+      if(s.paused) s.resume()
+
+      return res
+    }
+  }
 
   function drain () {
     waiting = false
@@ -134,4 +145,3 @@ function duplex (reader, read) {
 
   return s
 }
-

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -1,0 +1,18 @@
+var pull     = require('pull-stream')
+var defer    = require('pull-defer')
+var Readable = require('stream').Readable
+var duplex   = require('../')
+
+var test = require('tape')
+
+test('pipe - resume', function (t) {
+
+  var s = duplex(null, pull(pull.infinite(), pull.take(10)))
+  s.pause()
+
+  s.pipe(duplex(pull.collect(function (err, values) {
+    t.equal(values.length, 10)
+    t.end()
+  }), null))
+
+})


### PR DESCRIPTION
I found a lovely other issue when trying to do interop with other node streams. When a stream was paused before, readable streams are resumed when they get piped. This was not happening here.

Ref https://github.com/nodejs/node/blob/master/lib/_stream_readable.js#L606-L610
