### PR TITLE
fix stream "read" getting ahead of itself on resume

### DIFF
--- a/test/backpressure.js
+++ b/test/backpressure.js
@@ -52,3 +52,33 @@ test('backpressure', function (t) {
 
   r.pipe(s)
 })
+
+test('backpressure with constant resume', function (t) {
+  var values = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+
+  var s = duplex.source(pull(
+    pull.values(values),
+    pull.asyncMap(function (value, cb) {
+      setTimeout(function () {
+        // pass through value with delay
+        cb(null, value)
+      }, 10)
+    })
+  ))
+
+  var timer = setInterval(function () {
+    s.resume()
+  }, 5)
+
+  var output = []
+
+  s.on('data', function (c) {
+    output.push(c)
+  })
+
+  s.once('end', function () {
+    clearInterval(timer)
+    t.deepEqual(output, values, 'End called after all values emitted')
+    t.end()
+  })
+})


### PR DESCRIPTION
This was causing a bug in Loop Drop with the file exports.

When the [wave exporter I'm using](https://github.com/TooTallNate/node-wav/blob/master/lib/file-writer.js) calls `resume` before the asyncMap has returned (which seems to be when the disk is written faster than the export can convert), the stream jumps ahead and reads the next item before waiting for the previous read to complete. This causes `end` to be called early and pieces to be out of order.

This PR prevents `drain` from being able to run while the previous drain is still completing.

Not sure if this is the best way of handling, but it certainly fixes the problem in Loop Drop!  /cc @ahdinosaur @dominictarr