### PR TITLE
start readable stream in paused mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,6 +83,18 @@ function duplex (reader, read) {
 
   if(read) {
     s.sink(read)
+    s.paused = true
+
+    var on = s.on.bind(s)
+    s.on = (event, listener) => {
+      var res = on(event, listener)
+
+      if (event === 'data' && s.paused) {
+        next(s.resume.bind(s))
+      }
+
+      return res
+    }
 
     var pipe = s.pipe.bind(s)
     s.pipe = function (dest, opts) {

--- a/test/data-event.js
+++ b/test/data-event.js
@@ -1,0 +1,20 @@
+var pull     = require('pull-stream')
+var duplex   = require('../')
+
+var test = require('tape')
+
+test('should start to flow when data listener is added', function (t) {
+  var s = duplex(null, pull(pull.values(['hello'])))
+
+  setTimeout(() => {
+    s.on('data', (d) => {
+      t.equal(d, 'hello')
+      t.end()
+    })
+  }, 100)
+
+  setTimeout(() => {
+    t.fail('data event listener was not invoked')
+    t.end()
+  }, 200)
+})

--- a/test/error.js
+++ b/test/error.js
@@ -12,6 +12,7 @@ tape('test that error is emitted', function (t) {
     t.equal(err, error)
     t.end()
   })
+  s.on('data', () => {})
 })
 
 tape('error when paused', function (t) {


### PR DESCRIPTION
The [node docs say](https://nodejs.org/api/stream.html#stream_two_reading_modes):

> All Readable streams begin in paused mode but can be switched to flowing mode in one of the following ways:
>
> * Adding a 'data' event handler.
> * Calling the stream.resume() method.
> * Calling the stream.pipe() method to send the data to a Writable.

This module seems to return a stream that starts emitting data on the next tick and doesn't wait for the 'data' event handler to be added.

This PR:

1. Starts the stream in `paused` mode
2. Overrides the `.on` method on the stream to start data flowing when a `data` event is added in the same way that `.pipe` is overridden
3. Adds a test for the above